### PR TITLE
Fixes logging bug that occurs after log rotation

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -173,7 +173,7 @@ include /etc/logrotate.d
 /home/vof/app/log/production.log
 {
     weekly
-    size 100M
+    size 250M
     rotate 4
     create 0664 vof vof
     missingok
@@ -210,7 +210,7 @@ EOF
 # instance so supervisord is reload through this cron so that the app starts writing the log to the new log file.
 create_supervisord_cronjob() {
   cat > supervisord_cron <<'EOF'
-01 9 * * 5 supervisorctl update && supervisorctl reload
+1 9 * * * supervisorctl update && supervisorctl reload
 EOF
 }
 


### PR DESCRIPTION
#### What does this PR do?
Changes make supervisord restart, a daily action to counter effects of log rotation which create a new log file that the existing application fails to write to before a restart.

#### Description of Task to be completed?
Changes make supervisord restart, a daily action to counter effects of log rotation which create a new log file that the existing application fails to write to before a restart.

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A