### PR TITLE
#154919001: Add a sandbox environment for the developers

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -34,6 +34,7 @@ Below are the required environments variables that should be set for the pipelin
 12. **STAGING_RESERVED_IP**: GCP VOF project's staging environment reserved global static IP.
 13. **VOF_INFRASTRUCTURE_REPO**: Github link to the VOF infrastructure codebase.
 14. **DESIGN_V2_RESERVED_IP**: GCP VOF project's design-v2 environment reserved global static IP.
+15. **SANDBOX_RESERVED_IP**: GCP VOF project's sandbox environment reserved global static IP.
 
 #### Setting production and staging run-time environment variables in CircleCI
 ![production_envs](screenshots/production_envs.png?raw=true "Setting production environment variables")


### PR DESCRIPTION
#### What does this PR do?

This P.R adds a new environment on the vof application called sandbox. The environment is used by developers to test changes on their application without having to merge it on the develop branch and view it on staging. It caters for both the design-v2 and develop branch where a developer will follow the workflow on the slide below to trigger a sandbox environment using this script.

https://docs.google.com/presentation/d/16BSxT_o6wJ3ouG8_orFtGoASsCt_Q2rZlmkVXGjFg0Q/edit?usp=sharing


#### Description of Task to be completed?
Changes on this script alone:
- The task involved adding a script that could generate a random 64 digit number that would be added to the secrets.yml file of the vof application.
- It also required linking the new sandbox environment to it's own database file with the name vof-sandbox.sql. This file requires to be added on the vof-tracker app on gcp to be used for migrating the application database.
- It also required setting up system logs for google fluentd and continuous logrotation that is done by the weekly cron job.

Changes on the vof-tracker application:
The task required that developers can easily spin up a new environment to view their changes while the app is running on google cloud platform. It began by creating a new environment on the vof-tracker repo. In this case we created an environment called sandbox. The environment was similar to the production and staging environments but in addition we added a gem to allow better logging on the web browser for developers to use while testing. Other configurations such as debug to be true or using the web_console configuration were not visible on the browser. It then changes the configuration on circle CI, where a sandbox build would only be possible if the branch has the name sandbox either at the beginning, end or in the middle separated by hyphens. We regarded this as a control to only require deployment when required. 




#### How should this be manually tested?
On the vof-tracker application create a branch with the specifications on the slide as towards the naming of the branch. Commit a change and view your build on circle ci. You should see a workflow like the one below.
![image](https://user-images.githubusercontent.com/29925144/36193514-473b1f6e-1177-11e8-9d65-1003e3cc94dc.png)
Click on the release to sandbox button and this will release the sandbox.
After releasing you'll then get a workflow like the image below that requires you to destroy the sandbox.
![image](https://user-images.githubusercontent.com/29925144/36193589-80c1e038-1177-11e8-80eb-c4746518313f.png)
After using the sandbox visit the last circle CI build and click on the destroy button to finish the circle ci workflow.
![image](https://user-images.githubusercontent.com/29925144/36193486-2d40ab2e-1177-11e8-840c-271a3725fdab.png)


#### Any background context you want to provide?
This P.R needs to be merged first before testing the above changes on vof-tracker app.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/154919001
