### PR TITLE
#155931351: Automate redis server creation

### DIFF
--- a/vof-redis-base-image/packer.json
+++ b/vof-redis-base-image/packer.json
@@ -1,0 +1,29 @@
+{
+	"variables": {
+		"service_account_json": "../shared/account.json",
+		"env_name" : "{{env `RAILS_ENV`}}",
+		"project_id": "{{env `PROJECT_ID`}}"
+	},
+	"builders": [
+		{
+			"type": "googlecompute",
+			"project_id": "{{user `project_id`}}",
+			"machine_type": "g1-small",
+			"source_image": "ubuntu-1604-xenial-v20170815a",
+			"region": "europe-west1",
+			"zone": "europe-west1-b",
+			"ssh_username": "vof",
+			"image_description": "vof image for ruby on rails redis server",
+			"image_family": "ubuntu-1604-lts",
+			"image_name": "vof-redis-server-base-image",
+			"disk_size": 10,
+			"account_file": "{{ user `service_account_json`}}"
+		}
+	],
+	"provisioners": [
+		{
+			"type": "shell",
+			"script": "setup.sh"
+		}
+	]
+}

--- a/vof-redis-base-image/setup.sh
+++ b/vof-redis-base-image/setup.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+create_vof_user() {
+  if ! id -u vof; then
+    sudo useradd -m -s /bin/bash vof
+  fi
+}
+
+install_system_dependencies() {
+  sudo apt-get update -y && sudo apt-get upgrade -y
+  sudo apt-get install software-properties-common -y
+
+}
+
+install_redis(){
+  if ! which redis-cli; then
+    install_system_dependencies
+
+    sudo chgrp -R vof  /usr/local # make vof the group that /usr/local belongs to
+    sudo chmod -R g+rw /usr/local # give read and write permissions to the group that already owns these files
+
+    sudo add-apt-repository ppa:chris-lea/redis-server -y
+    sudo apt-get update -y
+    sudo apt-get install redis-server -y
+    sudo sed -i 's/127.0.0.1/0.0.0.0/g' /etc/redis/redis.conf
+    sudo service redis-server restart
+  fi
+}
+
+install_logging_agent(){
+  # This installs the logging agent into the VM
+  curl -sSO https://dl.google.com/cloudagents/install-logging-agent.sh
+  sudo bash install-logging-agent.sh
+}
+
+main() {
+  create_vof_user
+
+  mkdir -p /tmp/workdir
+  pushd /tmp/workdir #  store current dir and cd to /tmp/workdir
+    install_redis
+    install_logging_agent
+  popd #  cd to previosuly stored  path
+  rm -r /tmp/workdir
+
+}
+
+main "$@"

--- a/vof/compute.tf
+++ b/vof/compute.tf
@@ -57,7 +57,7 @@ resource "google_compute_instance_template" "vof-app-server-template" {
     databaseHost = "${google_sql_database_instance.vof-database-instance.ip_address.0.ip_address}"
     databasePort = "5432"
     databaseName = "${var.env_name}-vof-database"
-    redisIp = "${var.redis_ip}"
+    redisIp = "${google_compute_address.redis-ip.address}"
     railsEnv = "${var.env_name}"
     bucketName = "${var.bucket}"
     slackChannel = "${var.slack_channel}"

--- a/vof/redis.tf
+++ b/vof/redis.tf
@@ -1,0 +1,49 @@
+resource "google_compute_address" "redis-ip" {
+  name   = "${var.env_name}-redis-ip"
+  region = "${var.region}"
+}
+
+resource "google_compute_instance" "vof-redis-server" {
+  name         = "${var.env_name}-vof-redis-server"
+  machine_type = "${var.small_machine_type}"
+  zone         = "${var.zone}"
+
+  tags = ["http-server", "https-server", "${var.env_name}-redis-server"]
+
+  boot_disk {
+    initialize_params {
+      image = "vof-redis-server-base-image"
+    }
+  }
+
+  network_interface {
+    network = "${google_compute_network.vof-network.self_link}"
+
+    access_config {
+      // Ephemeral IP
+      nat_ip = "${google_compute_address.redis-ip.address}"
+    }
+  }
+
+  service_account {
+    email = "${var.service_account_email}"
+
+    scopes = ["https://www.googleapis.com/auth/monitoring.write", "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/logging.read",
+      "https://www.googleapis.com/auth/logging.write",
+    ]
+  }
+}
+
+resource "google_compute_firewall" "vof-redis-traffic-firewall" {
+  name    = "vof-${var.env_name}-redis-firewall"
+  network = "${google_compute_network.vof-network.self_link}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["6379"]
+  }
+
+  source_tags = ["${var.env_name}-vof-app-server"]
+  target_tags   = ["${var.env_name}-redis-server"]
+}


### PR DESCRIPTION
#### What does this PR do?

- Adds packer template and setup script for creation of a base redis server image
- Add infrastructure code to create the image using tf

#### Description of Task to be completed?

#### How should this be manually tested?
Navigate to the vof-redis-base-image directory and run
`packer build packer.json`
this will create an image on your GCP project

Then run
`terrafoam plan -out=plan-file`
to create a sequence of events for packer to run

Then run
`terrafoam apply "plan-file"`
to setup the infrastructure online

Ensure the redis_ip tf variable is set to a **reserved global ip** to ensure it works.

#### Any background context you want to provide?
Redis servers were previosuly created manually with either the GCP GUI or CLI

#### What are the relevant pivotal tracker stories?
[#155931351](https://www.pivotaltracker.com/story/show/155931351)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
