### PR TITLE
#156431930: Ensure only needed gems are installed on production and staging images

### DIFF
--- a/packer/packer.json
+++ b/packer/packer.json
@@ -29,6 +29,9 @@
 		},
 		{
 			"type": "shell",
+			"environment_vars": [
+				"RAILS_ENV={{user `env_name`}}"
+			],
 			"script": "setup.sh"
 		},
 		{

--- a/packer/setup.sh
+++ b/packer/setup.sh
@@ -11,7 +11,14 @@ create_vof_user() {
 
 setup_vof_code() {
   sudo chown -R vof:vof /home/vof 
-  cd /home/vof/app && bundle install
+  cd /home/vof/app
+
+  # ensure only the required gems are installed on production and staging
+  if [[ "$RAILS_ENV" == "production" || "$RAILS_ENV" == "staging" ]]; then
+    bundle install --without development test sandbox
+  else
+    bundle install  
+  fi
 }
 
 start_supervisor_service() {


### PR DESCRIPTION
#### What does this PR do?
It ensures only needed gems are installed on production and staging images

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
As I looked into the develop-old downtime issue, I noticed in the production environment there was a "spring" process being run by the puma server

<img width="732" alt="screen shot 2018-04-02 at 14 38 38" src="https://user-images.githubusercontent.com/9318050/38194961-95336330-3683-11e8-84ac-9e5783c42028.png">

This according to the [github page](https://github.com/rails/spring) is supposed to be used in development only and the gem must [not even be installed on the instance in the first place](https://github.com/rails/spring#deployment), which it is

<img width="549" alt="screen shot 2018-04-02 at 14 40 19" src="https://user-images.githubusercontent.com/9318050/38195005-cd3f84f2-3683-11e8-9444-b5dd53c02d24.png">

Further research led me to this [issue](https://github.com/rails/spring/issues/318) on the same GitHub page where a Rails [maintainer](https://github.com/rafaelfranca) mentioned
> It is expected that you run bundle install --without development test on production

[here](https://github.com/rails/spring/issues/318#issuecomment-47665343) . Hence the PR to correct this.

#### What are the relevant pivotal tracker stories?
[#156431930](https://www.pivotaltracker.com/story/show/156431930)

#### Screenshots (if appropriate)
Before while baking a production image, we had 130 gems installed
<img width="474" alt="screen shot 2018-04-02 at 14 50 42" src="https://user-images.githubusercontent.com/9318050/38196113-e04f9e6e-3689-11e8-8db8-047260cbd2e5.png">

Now while baking the image, we only have 80 gems installed
<img width="669" alt="screen shot 2018-04-02 at 15 19 56" src="https://user-images.githubusercontent.com/9318050/38196128-f14740c8-3689-11e8-8509-0dcb5b358905.png">

The output also tells us that

> Gems in the group development, test and sandbox were not installed.

Exactly as we would want it.

This PR must be merged after [this one](https://github.com/andela/vof-tracker/pull/936) and must be tested first to ensure no more "ghost" dependancies exist between the production environment and testing/development/sandbox environments. Dependancies are stable as of 15th May 2018.

#### Questions:
N/A
