### PR TITLE
 #155931351: Automate redis server creation (fix #2)

### DIFF
--- a/vof/compute.tf
+++ b/vof/compute.tf
@@ -58,7 +58,7 @@ resource "google_compute_instance_template" "vof-app-server-template" {
     databaseHost = "${google_sql_database_instance.vof-database-instance.ip_address.0.ip_address}"
     databasePort = "5432"
     databaseName = "${var.env_name}-vof-database"
-    redisIp = "${google_compute_address.redis-ip.network_interface.0.address}"
+    redisIp = "${google_compute_address.redis-ip.address}:6379"
     railsEnv = "${var.env_name}"
     bucketName = "${var.bucket}"
     slackChannel = "${var.slack_channel}"


### PR DESCRIPTION
#### What does this PR do?
- use external redis server IP for websocket connection
- dynamically authorize environment instances to use redis server
- use port ranges to allow instances reach redis instance

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
The previous fix merged appeared to work only for a short while. This has been more thoroughly tested.

#### What are the relevant pivotal tracker stories?
[#155931351](https://www.pivotaltracker.com/story/show/155931351)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
