### PR TITLE
#157184690: Add KLA, NBO and LAGOS IPs to access staging db

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -96,9 +96,14 @@ authenticate_service_account() {
 authorize_database_access_networks() {
   CURRENTIPS="$(gcloud compute instances list --project vof-tracker-app | grep ${RAILS_ENV}-vof-app-instance | awk -v ORS=, '{if ($5) print $5}' | sed 's/,$//')"
 
+  # authorize certain IPs to access staging db but not the production db
+  if [ "$RAILS_ENV" != "production" ]; then
+    $CURRENTIPS  = $CURRENTIPS,105.21.72.66,105.21.32.90,105.27.99.66,41.90.97.134,41.75.89.154,169.239.188.10,41.215.245.118
+  fi
+
   # ensure replica's authorized networks are also updated
   for sqlInstanceName in $(gcloud sql instances list --project vof-tracker-app | grep ${RAILS_ENV}-vof-database-instance | awk -v ORS=" " '{if ($1 !~ /production-vof-database-instance-vew0wndaum8/) print $1}'); do
-    gcloud sql instances patch $sqlInstanceName --quiet --authorized-networks=$CURRENTIPS,41.75.89.154,158.106.201.190,41.215.245.162,108.41.204.165,14.140.245.142,182.74.31.70,105.21.72.66,105.21.32.90,105.27.99.66,41.90.97.134,41.75.89.154,169.239.188.10,41.215.245.118
+    gcloud sql instances patch $sqlInstanceName --quiet --authorized-networks=$CURRENTIPS,41.75.89.154,158.106.201.190,41.215.245.162,108.41.204.165,14.140.245.142,182.74.31.70
   done 
 
 }

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -98,7 +98,7 @@ authorize_database_access_networks() {
 
   # ensure replica's authorized networks are also updated
   for sqlInstanceName in $(gcloud sql instances list --project vof-tracker-app | grep ${RAILS_ENV}-vof-database-instance | awk -v ORS=" " '{if ($1 !~ /production-vof-database-instance-vew0wndaum8/) print $1}'); do
-    gcloud sql instances patch $sqlInstanceName --quiet --authorized-networks=$CURRENTIPS,41.75.89.154,158.106.201.190,41.215.245.162,108.41.204.165,14.140.245.142,182.74.31.70
+    gcloud sql instances patch $sqlInstanceName --quiet --authorized-networks=$CURRENTIPS,41.75.89.154,158.106.201.190,41.215.245.162,108.41.204.165,14.140.245.142,182.74.31.70,105.21.72.66,105.21.32.90,105.27.99.66,41.90.97.134,41.75.89.154,169.239.188.10,41.215.245.118
   done 
 
 }

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -98,7 +98,7 @@ authorize_database_access_networks() {
 
   # authorize certain IPs to access staging db but not the production db
   if [ "$RAILS_ENV" != "production" ]; then
-    $CURRENTIPS  = $CURRENTIPS,105.21.72.66,105.21.32.90,105.27.99.66,41.90.97.134,41.75.89.154,169.239.188.10,41.215.245.118
+    CURRENTIPS="${CURRENTIPS},105.21.72.66,105.21.32.90,105.27.99.66,41.90.97.134,41.75.89.154,169.239.188.10,41.215.245.118"
   fi
 
   # ensure replica's authorized networks are also updated


### PR DESCRIPTION
#### What does this PR do?
This PR whitelists various IP addresses from the
Kampala, Nairobi and Lagos offices to allow developers
to be able to access the staging db data through a
postgres client.

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
Currently VOF developers need to go through DevOps Engineers to access the staging DB.

#### What are the relevant pivotal tracker stories?
[#157184690](https://www.pivotaltracker.com/n/projects/2126505/stories/157184690)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A