### PR TITLE
#157347094:  Ensure dynamic updates don't halt startup script

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -288,8 +288,12 @@ main() {
   create_secrets_yml
   create_vof_supervisord_conf
   authenticate_service_account
-  authorize_redis_access_ips
-  authorize_database_access_networks
+  set +o errexit
+  set +o pipefail
+    authorize_redis_access_ips
+    authorize_database_access_networks
+  set -o errexit
+  set -o pipefail
   get_database_dump_file
   start_bugsnag
   start_app


### PR DESCRIPTION
#### What does this PR do?
Allow execution of the start up script to continue even when dynamic updates fail

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
While replicating the downtime on staging, after doing this, I observed no downtime. The downtime is still a hard one to fix since I can't replicate on andela-learning but this gave a positive test, I'm hoping it will be a lasting solution to the downtime-during-deployments issue.

#### What are the relevant pivotal tracker stories?
[#157347094](https://www.pivotaltracker.com/story/show/157347094)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
