### PR TITLE
#158027985: Manage VOF application logs

### DIFF
--- a/packer/setup-scripts/setup_filebeat.sh
+++ b/packer/setup-scripts/setup_filebeat.sh
@@ -8,12 +8,13 @@ install_filebeat(){
 create_filebeat_config_file(){
 
   sudo mv /etc/filebeat/filebeat.yml /etc/filebeat/filebeat_old.yml
-  sudo bash -c 'cat <<EOF > /etc/filebeat/filebeat.yml
+  sudo bash -c "cat <<EOF > /etc/filebeat/filebeat.yml
 filebeat:
   prospectors:
     -
       paths:
         - /home/vof/app/log/logstash_*.log
+        exclude_lines: ['/health{1}']
       #  - /var/log/*.log
 
       input_type: log
@@ -24,18 +25,18 @@ filebeat:
 
 output:
   logstash:
-    hosts: ["192.168.1.2:5044"]
+    hosts: ['192.168.1.2:5044']
     bulk_max_size: 1024
 
     ssl:
-      certificate_authorities: ["/etc/pki/tls/certs/logstash-forwarder.crt"]
+      certificate_authorities: ['/etc/pki/tls/certs/logstash-forwarder.crt']
 
 shipper:
 
 logging:
   files:
     rotateeverybytes: 10485760 # = 10MB
-EOF'
+EOF"
 
 }
 

--- a/packer/setup-scripts/setup_metricbeat.sh
+++ b/packer/setup-scripts/setup_metricbeat.sh
@@ -25,7 +25,7 @@ metricbeat.modules:
     - socket
     - uptime
   enabled: true
-  period: 10s
+  period: 60s
   processes: ['.*']
   cpu_ticks: false
 

--- a/vof-elk-image/packer.json
+++ b/vof-elk-image/packer.json
@@ -1,6 +1,6 @@
 {
 	"variables": {
-		"service_account_json": "../shared/account-andela-learning.json",
+		"service_account_json": "../shared/account.json",
         "project_id": "{{env `PROJECT_ID`}}",
         "bucket_name": "{{env `BUCKET_NAME`}}"
 	},
@@ -16,7 +16,7 @@
 			"image_description": "image used to create an instance configured with elk",
 			"image_family": "ubuntu-1604-lts",
 			"image_name": "vof-elk-base-image",
-			"disk_size": 10,
+			"disk_size": 20,
 			"account_file": "{{ user `service_account_json`}}"
 		}
 	],

--- a/vof/variables.tf
+++ b/vof/variables.tf
@@ -71,7 +71,7 @@ variable "vof_disk_size" {
 
 variable "request_path" {
   type    = "string"
-  default = "/login"
+  default = "/health"
 }
 
 variable "check_interval_sec" {


### PR DESCRIPTION
#### What does this PR do?

- exlude healthcheck logs from being sent
  to our elk server to save valuable space
- increase metricbeat period to 60 seconds,
  this send logs to elk less often
- change the healthcheck route to '/health'
- increase elk space to 20GB so that its
  harder to reach the 85% disk storage
  threshold that locks logs from being
  received by elastic search

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#158027985](https://www.pivotaltracker.com/story/show/158027985)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
