### PR TITLE
#159105020 Increase loadbalancer timeout period

### DIFF
--- a/vof/compute.tf
+++ b/vof/compute.tf
@@ -3,6 +3,7 @@ resource "google_compute_backend_service" "web" {
   description = "VOF Load Balancer"
   port_name   = "customhttps"
   protocol    = "HTTPS"
+  timeout_sec = 120
   enable_cdn  = false
 
   backend {
@@ -10,7 +11,6 @@ resource "google_compute_backend_service" "web" {
   }
 
   session_affinity = "GENERATED_COOKIE"
-  timeout_sec      = 0
 
   health_checks = ["${google_compute_https_health_check.vof-app-healthcheck.self_link}"]
 }


### PR DESCRIPTION
#### What does this PR do?
 - increase the loadbalancer timeout period to 120 seconds as advised by
   the dev team so as to give more time to queries that take longer than
   30 seconds to execute. This helps us avoid some 502 errors related to
   downloads

#### Description of Task to be completed?
N/A

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#159105020](https://www.pivotaltracker.com/story/show/159105020)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A