### PR TITLE
#159070982 Breakdown start script

### DIFF
--- a/packer/setup-scripts/setup_fluentd.sh
+++ b/packer/setup-scripts/setup_fluentd.sh
@@ -1,0 +1,80 @@
+
+# this configures the application logging by google-fluentd to send application logs to
+# the google logging web UI just like all other logs like syslog and VM logs. For indepth explanation on how this is done and why everything is where it is
+# check out the logging documentation on this application's repo.
+configure_google_fluentd_logging() {
+
+  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_development_logs.conf
+<source>
+  @type tail
+  format none
+  path /home/vof/app/log/development.log
+  pos_file /var/lib/google-fluentd/pos/vof.pos
+  read_from_head true
+  tag vof_development_logs
+</source>
+EOF
+
+  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_sandbox_logs.conf
+<source>
+  @type tail
+  format none
+  path /home/vof/app/log/sandbox.log
+  pos_file /var/lib/google-fluentd/pos/vof.pos
+  read_from_head true
+  tag vof_sandbox_logs
+</source>
+EOF
+
+  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_production_logs.conf
+<source>
+  @type tail
+  format none
+  path /home/vof/app/log/production.log
+  pos_file /var/lib/google-fluentd/pos/vof.pos
+  read_from_head true
+  tag vof_production_logs
+</source>
+EOF
+
+  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_production_test_logs.conf
+<source>
+  @type tail
+  format none
+  path /home/vof/app/log/production_test.log
+  pos_file /var/lib/google-fluentd/pos/vof.pos
+  read_from_head true
+  tag vof_production_test_logs
+</source>
+EOF
+
+  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_staging_logs.conf
+<source>
+  @type tail
+  format none
+  path /home/vof/app/log/staging.log
+  pos_file /var/lib/google-fluentd/pos/vof.pos
+  read_from_head true
+  tag vof_staging_logs
+</source>
+EOF
+
+}
+
+# This configures the file responsible for tracking the last read position of the logs
+# by google-fluentd.
+configure_log_reader_positioning(){
+  sudo cat <<EOF > /var/lib/google-fluentd/pos/vof.pos
+/home/vof/app/log/production.log   000000000000000  000000000000000
+/home/vof/app/log/staging.log   000000000000000  000000000000000
+/home/vof/app/log/production_test.log  000000000000000  000000000000000
+/home/vof/app/log/development.log  000000000000000  000000000000000
+/home/vof/app/log/sandbox.log  000000000000000  000000000000000
+EOF
+}
+
+# this right here restarts the google fluentd service so that the above changes can take effect.
+restart_google_fuentd(){
+  sudo service google-fluentd stop
+  sudo service google-fluentd start
+}

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -207,84 +207,22 @@ start_app() {
   fi
   supervisorctl update && supervisorctl reload
 }
-
-# this configures the application logging by google-fluentd to send application logs to
-# the google logging web UI just like all other logs like syslog and VM logs. For indepth explanation on how this is done and why everything is where it is
-# check out the logging documentation on this application's repo.
 configure_google_fluentd_logging() {
-
-  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_development_logs.conf
-<source>
-  @type tail
-  format none
-  path /home/vof/app/log/development.log
-  pos_file /var/lib/google-fluentd/pos/vof.pos
-  read_from_head true
-  tag vof_development_logs
-</source>
+  cat > /etc/systemd/system/logging.service <<EOF
+[Unit]
+Description=google-fluentd logging configuration service
+After=network.target
+[Service]
+User=root
+ExecStart=/bin/bash /home/vof/setup-scripts/setup_fluentd.sh
+[Install]
+WantedBy=multi-user.target
 EOF
 
-  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_sandbox_logs.conf
-<source>
-  @type tail
-  format none
-  path /home/vof/app/log/sandbox.log
-  pos_file /var/lib/google-fluentd/pos/vof.pos
-  read_from_head true
-  tag vof_sandbox_logs
-</source>
-EOF
-
-  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_production_logs.conf
-<source>
-  @type tail
-  format none
-  path /home/vof/app/log/production.log
-  pos_file /var/lib/google-fluentd/pos/vof.pos
-  read_from_head true
-  tag vof_production_logs
-</source>
-EOF
-
-  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_production_test_logs.conf
-<source>
-  @type tail
-  format none
-  path /home/vof/app/log/production_test.log
-  pos_file /var/lib/google-fluentd/pos/vof.pos
-  read_from_head true
-  tag vof_production_test_logs
-</source>
-EOF
-
-  sudo cat <<EOF > /etc/google-fluentd/config.d/vof_staging_logs.conf
-<source>
-  @type tail
-  format none
-  path /home/vof/app/log/staging.log
-  pos_file /var/lib/google-fluentd/pos/vof.pos
-  read_from_head true
-  tag vof_staging_logs
-</source>
-EOF
-
-}
-
-# This configures the file responsible for tracking the last read position of the logs
-# by google-fluentd.
-configure_log_reader_positioning(){
-  sudo cat <<EOF > /var/lib/google-fluentd/pos/vof.pos
-/home/vof/app/log/production.log   000000000000000  000000000000000
-/home/vof/app/log/staging.log   000000000000000  000000000000000
-/home/vof/app/log/production_test.log  000000000000000  000000000000000
-/home/vof/app/log/development.log  000000000000000  000000000000000
-/home/vof/app/log/sandbox.log  000000000000000  000000000000000
-EOF
-}
-
-# this right here restarts the google fluentd service so that the above changes can take effect.
-restart_google_fuentd(){
-  sudo service google-fluentd restart
+  sudo chmod 664 /etc/systemd/system/logging.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable logging.service
+  sudo systemctl start logging.service
 }
 
 configure_logrotate() {
@@ -372,8 +310,6 @@ main() {
 
   start_app
   configure_google_fluentd_logging
-  configure_log_reader_positioning
-  restart_google_fuentd
 
   configure_logrotate
   create_unattended_upgrades_cronjob


### PR DESCRIPTION
#### What does this PR do?
Works on leaning out the start-vof.sh script to reduce run failures and eliminate resultant downtime

#### Description of Task to be completed?
- removed the google-fluentd setup into a separate script
- added a service to run the config script

#### How should this be manually tested?

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#159070982](https://www.pivotaltracker.com/story/show/159070982)

#### Screenshots (if appropriate)
N/A

#### Questions: