### PR TITLE
#159328586 Move filebeat installation to setup script and manage unattended upgrades (2)

### DIFF
--- a/packer/setup-scripts/setup_filebeat.sh
+++ b/packer/setup-scripts/setup_filebeat.sh
@@ -1,10 +1,3 @@
-install_filebeat(){
-  curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.2.4-amd64.deb
-  sudo dpkg -i filebeat-6.2.4-amd64.deb
-  sudo apt-get update
-  
-}
-
 create_filebeat_config_file(){
 
   sudo mv /etc/filebeat/filebeat.yml /etc/filebeat/filebeat_old.yml
@@ -19,7 +12,7 @@ filebeat:
       #  - /var/log/*.log
 
       input_type: log
-      
+
       document_type: syslog
 
   registry_file: /var/lib/filebeat/registry

--- a/packer/setup.sh
+++ b/packer/setup.sh
@@ -10,7 +10,7 @@ create_vof_user() {
 }
 
 setup_vof_code() {
-  sudo chown -R vof:vof /home/vof 
+  sudo chown -R vof:vof /home/vof
   cd /home/vof/app && bundle install
 }
 
@@ -18,11 +18,23 @@ start_supervisor_service() {
   sudo service supervisor start
 }
 
+install_filebeat() {
+  sudo systemctl stop apt-daily.service
+  sudo systemctl stop apt-daily.timer
+  sudo systemctl stop apt-daily-upgrade.service
+  sudo systemctl stop apt-daily-upgrade.timer
+  curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.2.4-amd64.deb
+  sudo dpkg -i filebeat-6.2.4-amd64.deb
+  sudo apt-get update
+}
+
 main() {
   create_vof_user
 
   setup_vof_code
   start_supervisor_service
+
+  install_filebeat
 }
 
 main "$@"

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -345,6 +345,13 @@ update_crontab() {
   rm upgrades_cron log_cron supervisord_cron
 }
 
+restart_unattended_upgrades() {
+  sudo systemctl start apt-daily.service
+  sudo systemctl start apt-daily.timer
+  sudo systemctl start apt-daily-upgrade.service
+  sudo systemctl start apt-daily-upgrade.timer
+}
+
 main() {
   echo "startup script invoked at $(date)" >> /tmp/script.log
 
@@ -364,7 +371,6 @@ main() {
   get_database_dump_file
   start_bugsnag
 
-  install_filebeat
   setup_filebeat
 
   install_metricbeat
@@ -379,6 +385,8 @@ main() {
   create_unattended_upgrades_cronjob
   create_supervisord_cronjob
   update_crontab
+
+  restart_unattended_upgrades
 
   # Setup Vault
   # source /home/vof/vault_token.sh


### PR DESCRIPTION
#### What does this PR do?
This PR fixes a bug that was affecting the installation of filebeat.

#### Description of Task to be completed?
Currently filebeat does not install when instances are being spun up due to a process, unattended upgrades, that is run automatically on the instance to update security patches, holding up the dpkg database which is also needed for filebeat to install. This stops the services that manage unattended upgrades before filebeat is installed to allow the unattended upgrades to complete and release the dpkg database and restarts them after all the steps in the start script have run.

#### How should this be manually tested?
After deployment, you can look at the bake image workflow logs and see that filebeat has been installed.

#### What are the relevant pivotal tracker stories?
[#159328586](https://www.pivotaltracker.com/story/show/159328586)