### PR TITLE
#159734041 Move filebeat and metric installations to the base image

### DIFF
--- a/packer/setup-scripts/setup_metricbeat.sh
+++ b/packer/setup-scripts/setup_metricbeat.sh
@@ -1,10 +1,3 @@
-
-install_metricbeat(){
-  curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-6.2.4-amd64.deb
-  sudo dpkg -i metricbeat-6.2.4-amd64.deb
-  sudo apt-get update
-}
-
 setup_metricbeat(){
 
   sudo bash -c 'cat <<EOF > /etc/metricbeat/metricbeat.yml

--- a/packer/setup.sh
+++ b/packer/setup.sh
@@ -18,23 +18,11 @@ start_supervisor_service() {
   sudo service supervisor start
 }
 
-install_filebeat() {
-  sudo systemctl stop apt-daily.service
-  sudo systemctl stop apt-daily.timer
-  sudo systemctl stop apt-daily-upgrade.service
-  sudo systemctl stop apt-daily-upgrade.timer
-  curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.2.4-amd64.deb
-  sudo dpkg -i filebeat-6.2.4-amd64.deb
-  sudo apt-get update
-}
-
 main() {
   create_vof_user
 
   setup_vof_code
   start_supervisor_service
-
-  install_filebeat
 }
 
 main "$@"

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -283,13 +283,6 @@ update_crontab() {
   rm upgrades_cron log_cron supervisord_cron
 }
 
-restart_unattended_upgrades() {
-  sudo systemctl start apt-daily.service
-  sudo systemctl start apt-daily.timer
-  sudo systemctl start apt-daily-upgrade.service
-  sudo systemctl start apt-daily-upgrade.timer
-}
-
 main() {
   echo "startup script invoked at $(date)" >> /tmp/script.log
 
@@ -310,8 +303,6 @@ main() {
   start_bugsnag
 
   setup_filebeat
-
-  install_metricbeat
   setup_metricbeat
 
   start_app
@@ -321,8 +312,6 @@ main() {
   create_unattended_upgrades_cronjob
   create_supervisord_cronjob
   update_crontab
-
-  restart_unattended_upgrades
 
   # Setup Vault
   # source /home/vof/vault_token.sh

--- a/vof_base_image/setup.sh
+++ b/vof_base_image/setup.sh
@@ -17,7 +17,7 @@ install_system_dependencies() {
   sudo apt-get install -y --no-install-recommends git-core curl zlib1g-dev logrotate     \
     build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev \
     sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev wget nodejs unattended-upgrades     \
-    python-software-properties libffi-dev libpq-dev sudo vim less supervisor jq 
+    python-software-properties libffi-dev libpq-dev sudo vim less supervisor jq
 }
 
 install_postgresql_9.6(){
@@ -65,6 +65,18 @@ install_logging_agent(){
   sudo bash install-logging-agent.sh
 }
 
+install_filebeat() {
+  curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-6.2.4-amd64.deb
+  sudo dpkg -i filebeat-6.2.4-amd64.deb
+  sudo apt-get update
+}
+
+install_metricbeat(){
+  curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-6.2.4-amd64.deb
+  sudo dpkg -i metricbeat-6.2.4-amd64.deb
+  sudo apt-get update
+}
+
 start_supervisor_service() {
   sudo service supervisor start
 }
@@ -77,6 +89,8 @@ main() {
     install_ruby
     install_vof_ruby_dependencies
     install_logging_agent
+    install_filebeat
+    install_metricbeat
   popd
   rm -r /tmp/workdir
 


### PR DESCRIPTION
#### What does this PR do?
This PR moves the filebeat and metricbeat installations to the `vof base image`.

#### Description of Task to be completed?
- Move install filebeat and metricbeat functions to the `vof base image` setup.sh
- Remove metricbeat installation step from the start_vof.sh
- Remove the install filebeat function from the setup_metricbeat.sh
- Remove filebeat installation from the `vof image` setup.sh
- Remove the restart unattended upgrades from start-script

#### Any background context you want to provide?
Currently metricbeat installation fails when instances are being spun up due to a process, unattended upgrades, that is run automatically on the instance to update security patches, holding up the dpkg database which is also needed for metricbeat to install. This is similar to an issue we were having with filebeat. It was solved by moving the installation to the `bake image` step in the workflow and stopping the services that handled unattended upgrades before installing filebeat and restarting them at the end of the start script. It worked for a while but the problem has resurfaced.

#### What are the relevant pivotal tracker stories?
[#159734041](https://www.pivotaltracker.com/story/show/159734041)