### PR TITLE
ch(dependencies) add imagemagick and bc to base image

### DIFF
--- a/vof_base_image/setup.sh
+++ b/vof_base_image/setup.sh
@@ -17,7 +17,7 @@ install_system_dependencies() {
   sudo apt-get install -y --no-install-recommends git-core curl zlib1g-dev logrotate     \
     build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev \
     sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev wget nodejs unattended-upgrades     \
-    python-software-properties libffi-dev libpq-dev sudo vim less supervisor jq
+    python-software-properties libffi-dev libpq-dev sudo vim less supervisor jq imagemagick bc
 }
 
 install_postgresql_9.6(){


### PR DESCRIPTION
#### What does this PR do?
- Adds ImageMagick
- Adds bc
#### Description of Task to be completed?
The above dependencies are added to solve a bug/error caught by BugSnag. Follow this [link](https://app.bugsnag.com/andela/vof-tracker-production/errors/5b770163d0d27a0019f17464?event_id=5b796ef1002acb6b5e310000&i=sk&m=oc) for details.

#### How should this be manually tested?
Seeing as the base image has been updated with the changes on GCP all new deployments won't have this issue.

#### What are the relevant pivotal tracker stories?
[#159861943](https://www.pivotaltracker.com/story/show/159861943)
[#159861904](https://www.pivotaltracker.com/story/show/159861904)
