### PR TITLE
#159863633 Add cronjob to delete unused images (2)

### DIFF
--- a/packer/delete_images.sh
+++ b/packer/delete_images.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# get environment variables from the metadata
+get_var() {
+  local name="$1"
+
+  curl -s -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/attributes/${name}"
+}
+
+export BUCKET_NAME=$(get_var "bucketName")
+export RAILS_ENV="$(get_var "railsEnv")"
+
+# pull the list of images from the GCP bucket
+gsutil cp gs://${BUCKET_NAME}/state/${RAILS_ENV}/images/image_tags.txt .
+#count the number of images(lines) in the file
+img_num=$(wc -l < image_tags.txt)
+# Check if the number of images is more than 10 to allow deleting the oldest ones
+# and leave the newest 10 to be on the safe side
+if [[ $img_num -gt 10 ]]; then
+  num_img_to_del=$(( img_num - 10 ))
+  # create a new file with the image names to be deleted
+  cat image_tags.txt | head -n $num_img_to_del > images_to_delete.txt
+  #loop through the new file picking the names and deleting them
+  for image_name in $(cat images_to_delete.txt); do
+    gcloud compute images delete $image_name --quiet
+    # Delete the image tags of the deleted images from the bucket file
+    sed -i "/${image_name}/d" ./image_tags.txt
+  done
+  gsutil cp /home/vof/image_tags.txt gs://${BUCKET_NAME}/state/${RAILS_ENV}/images/image_tags.txt
+fi
+
+#delete the txt files
+rm image_tag.txt
+rm images_to_delete.txt

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -1,65 +1,70 @@
 {
-	"variables": {
-		"service_account_json": "../shared/account.json",
-		"vof_path" : "{{env `VOF_PATH`}}",
-		"env_name" : "{{env `RAILS_ENV`}}",
-		"project_id": "{{env `PROJECT_ID`}}"
-	},
-	"builders": [
-		{
-			"type": "googlecompute",
-			"project_id": "{{user `project_id`}}",
-			"machine_type": "n1-standard-1",
-			"source_image": "vof-base-image-ruby",
-			"region": "europe-west1",
-			"zone": "europe-west1-b",
-			"ssh_username": "vof",
-			"image_description": "vof image for ruby on rails application",
-			"image_family": "ubuntu-1604-lts",
-			"image_name": "{{user `env_name`}}-vof-image-ruby-{{timestamp}}",
-			"disk_size": 10,
-			"account_file": "{{ user `service_account_json`}}"
-		}
-	],
-	"provisioners": [
-		{
-			"type": "file",
-			"source": "{{user `vof_path`}}",
-      		"destination": "/home/vof/app"
-		},
-		{
-			"type": "shell",
-			"script": "setup.sh"
-		},
-		{
-			"type": "file",
-			"source": "start_vof.sh",
-      		"destination": "/home/vof/start_vof.sh"
-		},
-		{
-			"type": "file",
-			"source": "setup-scripts",
-      		"destination": "/home/vof"
-		},
-		{
-			"type": "file",
-			"source": "vault_token.sh",
-      		"destination": "/home/vof/vault_token.sh"
-		},
-		{
-			"type": "file",
-			"source": "{{ user `service_account_json`}}",
-            "destination": "/home/vof/account.json"
-		},
-		{
-			"type": "file",
-			"source": "backup.sh",
-            "destination": "/home/vof/backup.sh"
-		},
-		{
-			"type": "file",
-			"source": "post_backup_to_slack.sh",
-            "destination": "/home/vof/post_backup_to_slack.sh"
-		}
-	]
+  "variables": {
+    "service_account_json": "../shared/account.json",
+    "vof_path": "{{env `VOF_PATH`}}",
+    "env_name": "{{env `RAILS_ENV`}}",
+    "project_id": "{{env `PROJECT_ID`}}"
+  },
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "{{user `project_id`}}",
+      "machine_type": "n1-standard-1",
+      "source_image": "vof-base-image-ruby",
+      "region": "europe-west1",
+      "zone": "europe-west1-b",
+      "ssh_username": "vof",
+      "image_description": "vof image for ruby on rails application",
+      "image_family": "ubuntu-1604-lts",
+      "image_name": "{{user `env_name`}}-vof-image-ruby-{{timestamp}}",
+      "disk_size": 10,
+      "account_file": "{{ user `service_account_json`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "{{user `vof_path`}}",
+      "destination": "/home/vof/app"
+    },
+    {
+      "type": "shell",
+      "script": "setup.sh"
+    },
+    {
+      "type": "file",
+      "source": "start_vof.sh",
+      "destination": "/home/vof/start_vof.sh"
+    },
+    {
+      "type": "file",
+      "source": "setup-scripts",
+      "destination": "/home/vof"
+    },
+    {
+      "type": "file",
+      "source": "vault_token.sh",
+      "destination": "/home/vof/vault_token.sh"
+    },
+    {
+      "type": "file",
+      "source": "{{ user `service_account_json`}}",
+      "destination": "/home/vof/account.json"
+    },
+    {
+      "type": "file",
+      "source": "backup.sh",
+      "destination": "/home/vof/backup.sh"
+    },
+    {
+      "type": "file",
+      "source": "post_backup_to_slack.sh",
+      "destination": "/home/vof/post_backup_to_slack.sh"
+    },
+    {
+      "type": "file",
+      "source": "delete_images.sh",
+      "destination": "/home/vof/delete_images.sh"
+    }
+  ]
 }

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -116,6 +116,21 @@ EOF
   fi
 }
 
+create_delete_images_cronjob() {
+  chmod 777 /home/vof/delete_images.sh
+  # add existing cronjobs to cron_delete_images to avoid overwriting them
+  if [ "$RAILS_ENV" == "production" ]; then
+    crontab -l -u vof > cron_delete_images
+  fi
+  cat >> cron_delete_images <<'EOF'
+# create cron job that deletes unused images every 1st of the month
+0 0 1 * * /bin/bash /home/vof/delete_images.sh >/dev/null 2>&1
+EOF
+
+  # add all cron jobs to crontabs
+  crontab -u vof cron_delete_images
+}
+
 create_secrets_yml() {
   cat <<EOF > /home/vof/app/config/secrets.yml
 production:
@@ -315,6 +330,7 @@ main() {
   start_app
   configure_google_fluentd_logging
 
+  create_delete_images_cronjob
   configure_logrotate
   create_unattended_upgrades_cronjob
   create_supervisord_cronjob


### PR DESCRIPTION
#### What does this PR do?
Adds a cronjob running a script every first of the month to delete unused images from GCP

#### Description of Task to be completed?
- Add a script that deletes unused images
- Add a cronjob that calls the script every 1st of the month
- Add the delete_images.sh script to the /home/vof directory

#### Any background context you want to provide?
Whenever a deployment happens, a new image is created with the new code and pushed to GCP, and the new image is used to run the app, after a few deployments, these images accumulate but only 2 of them are necessary, the one that is currently being used to run the app and the last previously used image in case we want to rollback. GCP charges for all each custom image so if it is not being used it should be deleted to avoid incurring unnecessary charges.

#### What are the relevant pivotal tracker stories?
[#159863633](https://www.pivotaltracker.com/story/show/159863633)