### PR TITLE
#158790623 Fix issue with 502 errors reporting implementation (2)

### DIFF
--- a/packer/downtime.sh
+++ b/packer/downtime.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+x=$(curl -I vof-url 2>/dev/null | head -n 1 | cut -d$' ' -f2)
+if [[ $x == 502 ]]; then
+  cpu_load=$(grep 'cpu ' /proc/stat | awk '{usage=($2+$4)*100/($2+$4+$5)} END {print usage}')
+  memory_load=$(free | grep Mem | awk '{print $3/$2 * 100.0}')
+  limit=70
+  # roundoff cpu load to 3 decimal places
+  cpu_load=$(printf "%.3f\n" $(echo $cpu_load | bc -l))
+  if (( $(awk 'BEGIN {print ("'$cpu_load'" >= "'$limit'")}') )); then
+    message="Instance has a memory leak, CPU load is greater than 70% on "$(hostname)
+    source /home/vof/.env_setup_rc; curl -X POST --data-urlencode "payload={\"channel\": \"$(echo $SLACK_CHANNEL)\", \"username\": \"loadbalancer\", \"text\": \"$message\", \"icon_emoji\": \":obama-sad:\"}" $(echo $SLACK_WEBHOOK)
+  fi
+  if (( $(awk 'BEGIN {print ("'$memory_load'" >= "'$limit'")}') )); then
+    message="Instance has a memory leak, Memory load is greater than 70% on "$(hostname)
+    source /home/vof/.env_setup_rc; curl -X POST --data-urlencode "payload={\"channel\": \"$(echo $SLACK_CHANNEL)\", \"username\": \"loadbalancer\", \"text\": \"$message\", \"icon_emoji\": \":obama-sad:\"}" $(echo $SLACK_WEBHOOK)
+  fi
+  message="vof alerts: Failing healthchecks on "$(hostname)
+  source /home/vof/.env_setup_rc; curl -X POST --data-urlencode "payload={\"channel\": \"$(echo $SLACK_CHANNEL)\", \"username\": \"loadbalancer\", \"text\": \"$message\", \"icon_emoji\": \":obama-sad:\"}" $(echo $SLACK_WEBHOOK)
+fi

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -65,6 +65,11 @@
       "type": "file",
       "source": "delete_images.sh",
       "destination": "/home/vof/delete_images.sh"
+    },
+    {
+      "type": "file",
+      "source": "downtime.sh",
+      "destination": "/home/vof/downtime.sh"
     }
   ]
 }

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -88,7 +88,7 @@ chmod 0600 /home/vof/.pgpass
 edit_postgresql_backup_file(){
   if [ "$RAILS_ENV" == "production" ]; then
     # create backups directory
-    mkdir /home/vof/backups
+    mkdir -p /home/vof/backups
     #change permissions on backup folder
     chmod 777 /home/vof/backups
     chmod 777 /home/vof/post_backup_to_slack.sh
@@ -118,7 +118,12 @@ EOF
 
 create_delete_images_cronjob() {
   chmod 777 /home/vof/delete_images.sh
+<<<<<<< HEAD
   # add existing cronjobs to cron_delete_images to avoid overwriting them
+=======
+  #On production, add existing cronjobs(post backups) to cron_delete_images
+  # to avoid overwriting it
+>>>>>>> chore(502 errors): fix issue with 502 errors reporting implementation
   if [ "$RAILS_ENV" == "production" ]; then
     crontab -l -u vof > cron_delete_images
   fi
@@ -131,6 +136,30 @@ EOF
   crontab -u vof cron_delete_images
 }
 
+<<<<<<< HEAD
+=======
+update_downtime_script(){
+  sudo chown vof:vof /home/vof/downtime.sh
+  chmod 777 /home/vof/downtime.sh
+  if [ "$RAILS_ENV" == "production" ]; then
+    sed -i 's/vof-url/vof.andela.com/g' /home/vof/downtime.sh
+  elif [ "$RAILS_ENV" == "staging" ]; then
+    sed -i 's/vof-url/vof-staging.andela.com/g' /home/vof/downtime.sh
+  else
+    sed -i 's/vof-url/vof-sandbox.andela.com/g' /home/vof/downtime.sh
+  fi
+  # add existing cronjobs to cron_file_downtime to avoid overriding them
+  crontab -l -u vof > cron_file_downtime
+  # append new cron job
+  cat >> cron_file_downtime <<'EOF'
+# create cron job that runs downtime script every minute
+*/1 * * * * /bin/bash /home/vof/downtime.sh
+EOF
+  # add all cron jobs to crontabs
+  crontab -u vof cron_file_downtime
+}
+
+>>>>>>> chore(502 errors): fix issue with 502 errors reporting implementation
 create_secrets_yml() {
   cat <<EOF > /home/vof/app/config/secrets.yml
 production:
@@ -331,6 +360,7 @@ main() {
   configure_google_fluentd_logging
 
   create_delete_images_cronjob
+  update_downtime_script
   configure_logrotate
   create_unattended_upgrades_cronjob
   create_supervisord_cronjob


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue with the implementation of 502 error reporting that led to downtime when the task was previously merged.

#### Description of Task to be completed?
add the downtime script for picking up down 502 errors
add cronjob to report 502 errors every minutes
add provisioner to add the dowtime script to the /home/vof dir
add a parents flag to the post backups function mkdir command

#### What are the relevant pivotal tracker stories?
[#158790623](https://www.pivotaltracker.com/story/show/158790623) [#159848993](https://www.pivotaltracker.com/story/show/159848993)