### PR TITLE
#159874326 Change when unattended upgrades run

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -118,7 +118,7 @@ EOF
 
 create_delete_images_cronjob() {
   chmod 777 /home/vof/delete_images.sh
-  #On production, add existing cronjobs(post backups) to cron_delete_images
+  # On production, add existing cronjobs(post backups) to cron_delete_images
   # to avoid overwriting it
   if [ "$RAILS_ENV" == "production" ]; then
     crontab -l -u vof > cron_delete_images
@@ -302,7 +302,7 @@ EOF
 
 create_unattended_upgrades_cronjob() {
   cat > upgrades_cron <<'EOF'
-0 9 * * 5 /bin/bash -lc 'source /home/vof/.env_setup_rc; curl -X POST --data-urlencode "payload={\"channel\": \"$(echo $SLACK_CHANNEL)\", \"username\": \"unattended-upgrades\", \"text\": \"*Unattended upgrades report from $(uname -n)*\n>>>$(sudo unattended-upgrade -v)\", \"icon_emoji\": \":bell:\"}" $(echo $SLACK_WEBHOOK)'
+0 1 * * 7 /bin/bash -lc 'source /home/vof/.env_setup_rc; curl -X POST --data-urlencode "payload={\"channel\": \"$(echo $SLACK_CHANNEL)\", \"username\": \"unattended-upgrades\", \"text\": \"*Unattended upgrades report from $(uname -n)*\n>>>$(sudo unattended-upgrade -v)\", \"icon_emoji\": \":bell:\"}" $(echo $SLACK_WEBHOOK)'
 EOF
 
 }


### PR DESCRIPTION
#### What does this PR do?
Changes the time when the unattended upgrades are triggered by a cronjob to run

#### Description of Task to be completed?
- change the day and time when the unattended upgrades cronjob runs from Friday morning to Sunday morning

#### Any background context you want to provide?
Currently the unattended upgrades are manually triggered by a cronjob on Friday however that uses up a lot of the resources on the instances and this is not ideal as it limits the amount of resources available to handle the users tasks

#### What are the relevant pivotal tracker stories?
[#159874326](https://www.pivotaltracker.com/story/show/159874326) [#159874322](https://www.pivotaltracker.com/story/show/159874322) 