### PR TITLE
creates a function to add a cronjob

### DIFF
--- a/vof-elk-image/start_elk.sh
+++ b/vof-elk-image/start_elk.sh
@@ -82,23 +82,18 @@ update_crontab() {
 #this functions calls a command to unlock kibana and allow it to receive all the logs.
 #logs are blocked incase the instance reaches the memory threshold. They must be manually unlocked
 add_cronjob_to_unlock_logs_daily() {
-
-  sudo touch /etc/cron.daily/unlock-kibana-logs
-
+    sudo touch /etc/cron.daily/unlock-kibana-logs
     cat <<EOF > /etc/cron.daily/unlock-kibana-logs
 curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
 EOF
-
 }
 
 main() {
 
   configure_logstash_ssl
-  
   create_logstash_input_config
   create_logstash_filter_config
   create_logstash_output_config
-
   create_curator_cronjob
   update_crontab
   add_cronjob_to_unlock_logs_daily

--- a/vof-elk-image/start_elk.sh
+++ b/vof-elk-image/start_elk.sh
@@ -78,6 +78,19 @@ update_crontab() {
   rm /home/elk/curator/curator_cron.yml
 }
 
+#add a job to the daily crontab directory
+#this functions calls a command to unlock kibana and allow it to receive all the logs.
+#logs are blocked incase the instance reaches the memory threshold. They must be manually unlocked
+add_cronjob_to_unlock_logs_daily() {
+
+  sudo touch /etc/cron.daily/unlock-kibana-logs
+
+    cat <<EOF > /etc/cron.daily/unlock-kibana-logs
+curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
+EOF
+
+}
+
 main() {
 
   configure_logstash_ssl
@@ -88,6 +101,7 @@ main() {
 
   create_curator_cronjob
   update_crontab
+  add_cronjob_to_unlock_logs_daily
 }
 
 main "$@"


### PR DESCRIPTION
#### What does this PR do?
Adds a cronjob for a daily routine of unlocking the kibana instance for receiving the logs from the 

#### Description of Task to be completed?
- Creates a file under the directory '/etc/cron.daily/unlock-kibana-logs`
- Configure the file to run daily by placing it under the `cron.daily` directory

#### How should this be manually tested?

#### Any background context you want to provide?

Kibana stays read only when ES high disk watermark has been exceeded and later gone beneath the limit. For this reason, we are not able to access the most recent logs from vof applications. i.e vof-staging, vof-sandbox, vof-production. 
In case we want to update the instance, the unlocking has to be done manually.

#### What are the relevant pivotal tracker stories?
[2126505](https://www.pivotaltracker.com/story/show/160239422) 

[160239584](https://www.pivotaltracker.com/story/show/160239584)

#### Screenshots (if appropriate)

#### Questions: