### PR TITLE
change binary logs param to false

### DIFF
--- a/vof/database.tf
+++ b/vof/database.tf
@@ -30,7 +30,7 @@ resource "google_sql_database_instance" "vof-database-instance" {
     }
 
     backup_configuration {
-      binary_log_enabled = true
+      binary_log_enabled = false
       enabled = true
       start_time = "${var.db_backup_start_time}"
     }


### PR DESCRIPTION
#### What does this PR do?

Fix the error currently being experienced when orchestrating the vof infrastructure. This is incompatibility issue with postgres bunary logs as seen on the image below
<img width="1268" alt="screen shot 2018-09-08 at 22 46 56" src="https://user-images.githubusercontent.com/13331207/45258132-3ee12980-b3bb-11e8-8a49-89c99f24a1ba.png">


#### Description of Task to be completed?
- Change the value of `binary_logs_anabled` to `false`

#### How should this be manually tested?
- Change the value mentioned above.
- Point the the environment variable in circleCI `VOF_INFRASTRUCTURE_REPO` the repo that changed the value and trigger a build.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[160366251](https://www.pivotaltracker.com/story/show/160366251)

#### Screenshots (if appropriate)
N/A

#### Questions: