### PR TITLE
#160633876 Set terraform gcp provider version to 1.17

### DIFF
--- a/vof/main.tf
+++ b/vof/main.tf
@@ -1,7 +1,8 @@
 provider "google" {
+  version     = "<= 1.17"
   credentials = "${file("${var.credential_file}")}"
-  project = "${var.project_id}"
-  region = "${var.region}"
+  project     = "${var.project_id}"
+  region      = "${var.region}"
 }
 
 terraform {
@@ -12,10 +13,11 @@ terraform {
 
 data "terraform_remote_state" "vof" {
   backend = "gcs"
+
   config {
-    bucket = "${var.bucket}"
-    path = "${var.state_path}"
-    project = "${var.project_id}"
+    bucket      = "${var.bucket}"
+    path        = "${var.state_path}"
+    project     = "${var.project_id}"
     credentials = "${file("${var.credential_file}")}"
   }
 }


### PR DESCRIPTION
 #### What does this PR do?
  - set the GCP provider version to 1.17

#### Description of Task to be completed?
Set the version of the GCP provider to v1.17

#### Any background context you want to provide?
Terraform upgraded the gcp provider and the upgrade introduced a bug which changed the way that the instance templates pick up the application images

#### What are the relevant pivotal tracker stories?
[#160633743](https://www.pivotaltracker.com/story/show/160633743) [160633876](https://www.pivotaltracker.com/story/show/160633876)

#### Screenshots (if appropriate)
![screen shot 2018-09-19 at 22 20 44](https://user-images.githubusercontent.com/5388763/45776045-5a212400-bc5a-11e8-92bf-e83cbf21a2aa.png)