### PR TITLE
#162393139 Add redis replica setup script

### DIFF
--- a/utilities/redis_replication_setup.sh
+++ b/utilities/redis_replication_setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+:'
+This utility script is intended to automate the setup of the Redis Replication set.
+Once the StatefulSet app is deployed on the kubernetes cluster of choice, this script
+should be run to set up the replica chain.
+
+It uses the kubectl commandline tool to retrieve the IPs of all the redis server pods,
+then creates an array of said IPs and executes the REPLICAOF command in respective
+to create a "daisy chain" replica set; where the next server in the series is a slave/replica
+of its predecessor.
+
+# How to use
+The usage of the script is quite simple but has the following prerequistes
+    1. Ensure you have the kubectl commandline tool installed and accessible through bash
+    2. Ensure the current cluster context is the one the apprenticeship-redis StatefulSet 
+       app is deployed to.
+
+To execute, cd into the the utilities directory and run either of the following commands
+
+  $ ./redis_replication_setup.sh main
+
+  $ ../redis_replication_setup.sh assign_replicas
+'
+
+assign_replicas() {
+    # Get the server IPs
+    redisServerIPs=$(kubectl get pods -o jsonpath='{range.items[*]}{.status.podIP};' | tr ";" "\n")
+    # initialize array index
+    i=0
+    # loop through the set of IPs creating an array 
+    for server in ${redisServerIPs}
+    do
+        servers[$i]=$server
+        ((i++))
+    done
+
+    # Loop through the array setting the next server as a replica of the 
+    # current server
+    for ((j=0;j<${#servers[@]};j++))
+    do
+        ((k=j+1))
+        if [ "$k" != "${#servers[@]}" ]; then
+            kubectl exec -it apprenticeship-redis-$k -- redis-cli REPLICAOF ${servers[j]} 6379
+        fi
+    done
+}
+
+main() {
+    assign_replicas
+}
+
+"$@"


### PR DESCRIPTION
#### What does this PR do?
- Adds Redis replication automation script

#### Description of Task to be completed?
For faster, more efficient and scalable Redis setup, this PR adds a simple replication setup script.

#### How should this be manually tested?
1. Create a testing cluster: you can use Minikube locally
2. Deploy the Redis StatefulSet app to the cluster with the manifests in the `k8s/redis/` folder
3. `cd` into *utilities* directory and execute run either of the commands below
```bash
$ ./redis_replication_setup main
```
or
```bash
$ ./redis_replication_setup assign_replicas
```

#### What are the relevant pivotal tracker stories?
[#162393139](https://www.pivotaltracker.com/story/show/162393139)
