### PR TITLE
#163188322 Create ELK cluster on the shared apprenticeship 

### DIFF
--- a/terraform/admin/compute.tf
+++ b/terraform/admin/compute.tf
@@ -109,3 +109,31 @@ resource "google_container_cluster" "admin-redis-elk-cluster" {
     tags = ["apprenticeship", "elk", "redis"]
   }
 }
+
+resource "google_container_cluster" "admin-elk-cluster" {
+  name               = "shared-elk-cluster"
+  zone               = "europe-west1-b"
+  initial_node_count = 2
+  network = "${module.network.self_link}"
+  subnetwork = "${module.network.public_network_name}"
+
+  master_auth {
+    username = "apprenticeshipadmin"
+    password = "${var.admin_cluster_master_password}"
+  }
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    labels {
+      project_name = "apprenticeship"
+    }
+
+    tags = ["apprenticeship", "elk"]
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Create a cluster in apprenticeship-projects named shared-elk-cluster that should be in the shared network.
#### Description of Task to be completed?
- Create a new cluster via terraform
- Specify which network it should be created in

#### How should this be manually tested?
N/A
#### Any background context you want to provide?
Some of the products on GKE may deny connections outside of VPC/shared network. Since most of the applications in apprenticeship will be using the ELK, it should be created in the shared network.

#### What are the relevant pivotal tracker stories?
[163188322](https://www.pivotaltracker.com/story/show/163188322)
#### Screenshots (if appropriate)

#### Questions:
N/A