### PR TITLE
#162951188 Seed staging db with production db

### DIFF
--- a/packer/backup_to_gcp.sh
+++ b/packer/backup_to_gcp.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#make a backup of the database
+#var to hold date timestamp
+dump_date= `date + "%Y"`-`date +"%m"`-`date +"%d"`
+pg_dump -F p -f /home/vof/backups/gcp/vof-production-db-backup-$dump_date.sql
+#post the backup to GCP
+#post to bucket
+gsutils cp /home/vof/backups/gcp/vof-production-db-backup-$dump_date.sql  gs://vof-tracker-app/database-backups/vof-production-db-backup-$dump_date.sql
+#prune old backups
+find /home/vof/backups/gcp/ -maxdepth 1 -mtime +14 -name "*sql" exec rm -rf '{}' ';'

--- a/packer/packer.json
+++ b/packer/packer.json
@@ -58,6 +58,16 @@
     },
     {
       "type": "file",
+      "source": "backup_to_gcp.sh",
+      "destination": "/home/vof/backup_to_gcp.sh"
+    },
+    {
+      "type": "file",
+      "source": "backup_to_gcp.sh",
+      "destination": "/home/vof/seed_prod_backup_to_staging.sh"
+    },
+    {
+      "type": "file",
       "source": "post_backup_to_slack.sh",
       "destination": "/home/vof/post_backup_to_slack.sh"
     },

--- a/packer/seed_prod_backup_to_staging.sh
+++ b/packer/seed_prod_backup_to_staging.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#var to hold date timestamp
+dump_date= `date + "%Y"`-`date +"%m"`-`date +"%d"`
+#pull the production database from GCP
+gsutils cp gs://vof-tracker-app/database-backups/vof-production-db-backup-$dump_date.sql /home/vof/vof-production-db-backup-$dump_date.sql
+#clear the database before importing
+sudo -u postgres bash -c "export PGPASSWORD=$(get_var "databasePassword"); dropdb '$(get_var "databaseName")' "
+#force import to staging
+sudo -u postgres bash -c "export PGPASSWORD=$(get_var "databasePassword"); psql -h  $(get_var "databaseHost") -p 5432 -U $(get_var "databaseUser") -d $(get_var "databaseName") < /home/vof/vof-production-db-backup-`date + "%Y"`-`date +"%m"`-`date +"%d"`.sql"
+  

--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -98,6 +98,7 @@ edit_postgresql_backup_file(){
     # edit backup script to include required parameters
     sed -i "s/pg_dump/pg_dump -h '$(get_var "databaseHost")' -U '$(get_var "databaseUser")' -d '$(get_var "databaseName")'/g" /home/vof/backup.sh
     sed -i "s/token=/token='$(get_var "dbBackupNotificationToken")'/g" /home/vof/post_backup_to_slack.sh
+    sed -i "s/pg_dump/pg_dump -h '$(get_var "databasehost")' -U '$(get_var "databaseUser")' -d '$(get_var "databaseName")'/g" /home/vof/backup_to_gcp.sh
     #make vof user owner of backup.sh file
     sudo chown vof:vof /home/vof/backup.sh
     # change permissions on backup.sh file
@@ -110,9 +111,26 @@ edit_postgresql_backup_file(){
 0 21 * * * /bin/bash /home/vof/post_backup_to_slack.sh
 # create cron job to delete database backup files from server at 00:05 EAT daily
 5 21 * * * /bin/rm -r /home/vof/backups/vof-*
+
+#create cron job to backup db and send it GCP bucket
+
+#  $(($(date +%W)%2)) "W" stands for a week number the year. Starting from zero to 53. If it can be divided by two, 
+#  then it's "every second" week on saturday
+
+0 22 * * 6 test $((10#$(date +\%W)\%2)) -eq 1 && /bin/bash /home/vof/backup_to_gcp.sh
 EOF
+
+  elif [ "$RAILS_ENV" == "staging"]: then
+  #create cronjobs to work on stafging
+    cat > staging_cron_file <<'EOF'
+#create a cronjob that forces db import 1 hour after it has been backed up
+0 23 * * 6 test $((10#$(date +\%W)\%2)) -eq 1 && /bin/bash /home/vof/seed_prod_backup_to_staging.sh
+
+EOF
+
     # add cron jobs to crontab
     crontab -u vof cron_file_create
+    crontab -u vof staging_cron_file
   fi
 }
 
@@ -346,12 +364,12 @@ main() {
 
   create_log_files
   create_pgpass_file
+  authenticate_service_account
   edit_postgresql_backup_file
   update_application_yml
   create_secrets_yml
   create_vof_supervisord_conf
   create_sidekiq_supervisord_conf
-  authenticate_service_account
   set +o errexit
   set +o pipefail
     authorize_redis_access_ips

--- a/vof_base_image/packer.json
+++ b/vof_base_image/packer.json
@@ -24,5 +24,6 @@
 			"type": "shell",
 			"script": "setup.sh"
 		}
+		
 	]
 }


### PR DESCRIPTION
#### What does this PR do?
Create a cronjob that seeds production database to staging database after every 2 weeks.
#### Description of Task to be completed?
- Create a cronjob that sends the database dump to gcp bucket
- Edit the dump file to include the required parameters for a successful import to take place.
- Create a cronjob that pulls the db dump- backed up production dump- from staging environment.
- Import the database dump into the staging environment

#### How should this be manually tested?
- `clone` this repo
- `git checkout ft-cronjob-seed-staging-production-db-162951188`
- To make sure you don't wait for 2 weeks to test this, change the file `packer/start_vof.sh` on line 121 and use a considerable time. for example after 1 hour or 30 mins.
That would look something like this, 
`30 * * * * && /bin/bash /home/vof/backup_to_gcp.sh` 

- Also, change the time for the scheduled db import. Ideally this should be 1 hour after the back up has been done. so on line 128 could be changed to,
`30 1 * * *  && /bin/bash /home/vof/seed_prod_backup_to_staging.sh`
- After your deployment, go to GCP and the bucket you specified to store the db dumb and check if it exists.

#### Any background context you want to provide?
For the devs to be in sync with the latest data in production they need requested that this task be taken up.
#### What are the relevant pivotal tracker stories?
[162951188](https://www.pivotaltracker.com/story/show/162951188)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A