### PR TITLE
#163619583 Fixes syntax error in start_up script

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -124,18 +124,18 @@ edit_postgresql_backup_file(){
 0 22 * * 6 test $((10#$(date +\%W)\%2)) -eq 1 && /bin/bash /home/vof/backup_to_gcp.sh
 EOF
 
-  elif [ "$RAILS_ENV" == "staging"]: then
-  #create cronjobs to work on stafging
+  elif [ "$RAILS_ENV" == "staging" ]; then
+  #create cronjobs to work on staging
     cat > staging_cron_file <<'EOF'
 #create a cronjob that forces db import 1 hour after it has been backed up
 0 23 * * 6 test $((10#$(date +\%W)\%2)) -eq 1 && /bin/bash /home/vof/seed_prod_backup_to_staging.sh
 
 EOF
 
+  fi
     # add cron jobs to crontab
     crontab -u vof cron_file_create
     crontab -u vof staging_cron_file
-  fi
 }
 
 create_delete_images_cronjob() {


### PR DESCRIPTION
#### What does this PR do?
Fixes the syntax error in one of the functions since the error is causing deployment failures.

#### Description of Task to be completed?
* corrected the syntax error in the conditional statement on the database backup management functionality.

#### How should this be manually tested?
* Once this PR is merged, the error in [the screenshot below](https://user-images.githubusercontent.com/30072633/52050766-aa8e8380-2562-11e9-99ce-6db9bf1df4ad.png) should desist.

#### Any background context you want to provide?
* There were some additions to the database backup management section of the start_up.sh script that had syntax error that we'd missed. This was and remains to be a rare oversight on our part and should never occur again.

#### What are the relevant pivotal tracker stories?
[#163619583](https://www.pivotaltracker.com/story/show/163619583)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30072633/52050766-aa8e8380-2562-11e9-99ce-6db9bf1df4ad.png)

#### Questions: