### PR TITLE
#163619583 Fix semantic error in start_up script

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -124,6 +124,9 @@ edit_postgresql_backup_file(){
 0 22 * * 6 test $((10#$(date +\%W)\%2)) -eq 1 && /bin/bash /home/vof/backup_to_gcp.sh
 EOF
 
+  # add cron job to crontab
+  crontab -u vof cron_file_create
+
   elif [ "$RAILS_ENV" == "staging" ]; then
   #create cronjobs to work on staging
     cat > staging_cron_file <<'EOF'
@@ -132,10 +135,9 @@ EOF
 
 EOF
 
-  fi
-    # add cron jobs to crontab
-    crontab -u vof cron_file_create
+    # add cron job to crontab
     crontab -u vof staging_cron_file
+  fi
 }
 
 create_delete_images_cronjob() {


### PR DESCRIPTION
#### What does this PR do?
* Fixes the semantic error in one of the functions since the error is causing deployment failures.

#### Description of Task to be completed?
* Fixed the addition of the database management cron jobs.

#### How should this be manually tested?
* The start_up script should execute to completion without error.

#### Any background context you want to provide?
* This work is continued from a similar PR meant to address a [syntax error](https://github.com/andela/vof-deployment-scripts/pull/120) in the script.

#### What are the relevant pivotal tracker stories?
[#163619583](https://www.pivotaltracker.com/story/show/163619583)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30072633/52056522-91da9980-2573-11e9-86e7-32e58c56314b.png)

#### Questions: